### PR TITLE
Chore/updatejquery version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,12 @@ jobs:
           at: .
       - restore_cache:
           key: node-cache-v3-{{ checksum "package.json" }}
+      # Install latest chrome
+      - run: wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+      - run: echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee -a /etc/apt/sources.list
+      - run: sudo apt-get update -qq
+      - run: sudo apt-get install -y google-chrome-stable
+      # Run tests          
       - run: NODE_ENV=dev npm run test
 
   build:

--- a/bower.json
+++ b/bower.json
@@ -33,6 +33,7 @@
     "angular": "1.2.18",
     "angular-route": "1.2.18",
     "auto-scroll": "https://github.com/Rise-Vision/auto-scroll.git#2.0.2",
+    "jquery": "3.3.1",
     "moment": "~2.8.3",
     "moment-range": "~1.0.5",
     "rv-common-style": "https://github.com/Rise-Vision/common-style.git#1.1.12",
@@ -46,6 +47,6 @@
     "angular-bootstrap": "~0.11.1",
     "angular-translate": "~2.5.2",
     "angular-translate-loader-static-files": "~2.5.2",
-    "jquery": "1.11.0"
+    "jquery": "3.3.1"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -33,7 +33,7 @@
     "angular": "1.2.18",
     "angular-route": "1.2.18",
     "auto-scroll": "https://github.com/Rise-Vision/auto-scroll.git#2.0.2",
-    "jquery": "3.3.1",
+    "jquery": "~3.3.1",
     "moment": "~2.8.3",
     "moment-range": "~1.0.5",
     "rv-common-style": "https://github.com/Rise-Vision/common-style.git#1.1.12",
@@ -45,6 +45,6 @@
   "resolutions": {
     "angular": "1.2.18",
     "angular-bootstrap": "~0.11.1",
-    "jquery": "3.3.1"
+    "jquery": "~3.3.1"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -45,8 +45,6 @@
   "resolutions": {
     "angular": "1.2.18",
     "angular-bootstrap": "~0.11.1",
-    "angular-translate": "~2.5.2",
-    "angular-translate-loader-static-files": "~2.5.2",
     "jquery": "3.3.1"
   }
 }

--- a/src/settings.html
+++ b/src/settings.html
@@ -217,7 +217,7 @@
     </div>
   </div>
 
-  <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+  <script src="//ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 
   <!-- build:js js/settings.min.js -->
   <script src="components/angular-translate/angular-translate.js"></script>


### PR DESCRIPTION
## Description
Updates JQuery version

## Motivation and Context
JQuery update was required as [part of Security Audit](https://docs.google.com/document/d/1QBTcp_si33Od29Nv-qBlzA6Lj9RrKnVBrBabQYCjwMs/edit#heading=h.97ox305v56sc).

I tried to also update Angular version to latest, but had problems with tests, all my attempts in this other branch: 
https://github.com/Rise-Vision/widget-google-calendar/compare/chore/update-jquery?expand=1

It's failing with a script timeout, and I didn't want to dive in more deeply in this for the time being.

## How Has This Been Tested?
Manually tested using staged calendar settings here:
https://apps.risevision.com/editor/workspace/624cb743-d8a9-4e28-a1c6-3527e026b173?cid=30007b45-3df0-4c7b-9f7f-7d8ce6443013

And the runtime component was tested also in preview and in player using this schedule:
https://apps.risevision.com/schedules/details/710a1da0-8e90-43f4-9836-f8dfbdb03fae?cid=30007b45-3df0-4c7b-9f7f-7d8ce6443013

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
     - To be released before Friday.
     - No new automated tests are needed.
     - Release plan, to be validated immediately after deployment.
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No need to notify support. No need to update documentation.
