### PR TITLE
Fix for #152 - do not show error message on display

### DIFF
--- a/src/widget/calendar.js
+++ b/src/widget/calendar.js
@@ -82,9 +82,10 @@ RiseVision.Calendar = (function (gadgets) {
           if (reason.result.error.code && reason.result.error.code === -1) {
             startRefreshTimer();
           }
-          else {
-            $(".error").show();
-          }
+          // issue 152 - do not show any messages on display
+          // else {
+          //   $(".error").show();
+          // }
         }
 
         if (isLoading) {


### PR DESCRIPTION
## Description
- Fix for #152 
- Do not show error message. 

@stulees I decided to make the minimal changes and just comment out the code that shows the error message on display. Main reasons are:

- Every few years we tend to change the decision re. informing user about the error vs not showing any messages, so we might still need that code in the future.
- The ["error" class in HTML](https://github.com/Rise-Vision/widget-google-calendar/blob/9f48fec0f3df031c0f226927aa7a1cc3fd24b6f9/src/widget.html#L16) is referenced in few places in the code ([example](https://github.com/Rise-Vision/widget-google-calendar/blob/9f48fec0f3df031c0f226927aa7a1cc3fd24b6f9/src/widget/calendar.js#L58)). I'd like to avoid making changes in many places and then retesting all those use cases. If it's working don't touch it 😉 .

## Motivation and Context
Fix issue

## How Has This Been Tested?
Tested locally using Charles Proxy

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
