### PR TITLE
Change layout URL

### DIFF
--- a/src/config/prod.js
+++ b/src/config/prod.js
@@ -5,7 +5,7 @@ var config = {
 
 if (typeof angular !== "undefined") {
   angular.module("risevision.widget.googleCalendar.config", [])
-    .value("defaultLayout", "http://s3.amazonaws.com/widget-google-calendar/0.1.0/dist/widget.html");
+    .value("defaultLayout", "http://widgets.risevision.com/widget-google-calendar/0.1.0/dist/widget.html");
 
   angular.module("risevision.common.i18n.config", [])
     .constant("LOCALES_PREFIX", "locales/translation_")

--- a/src/config/prod.js
+++ b/src/config/prod.js
@@ -5,7 +5,7 @@ var config = {
 
 if (typeof angular !== "undefined") {
   angular.module("risevision.widget.googleCalendar.config", [])
-    .value("defaultLayout", "http://widgets.risevision.com/widget-google-calendar/0.1.0/dist/widget.html");
+    .value("defaultLayout", "https://widgets.risevision.com/widget-google-calendar/0.1.0/dist/widget.html");
 
   angular.module("risevision.common.i18n.config", [])
     .constant("LOCALES_PREFIX", "locales/translation_")

--- a/src/config/test.js
+++ b/src/config/test.js
@@ -5,7 +5,7 @@ var config = {
 
 if (typeof angular !== "undefined") {
   angular.module("risevision.widget.googleCalendar.config", [])
-    .value("defaultLayout", "http://s3.amazonaws.com/widget-google-calendar-test/0.1.0/dist/widget.html");
+    .value("defaultLayout", "http://widgets.risevision.com/widget-google-calendar-test/stage-0/0.1.0/dist/widget.html");
 
   angular.module("risevision.common.i18n.config", [])
     .constant("LOCALES_PREFIX", "locales/translation_")

--- a/src/config/test.js
+++ b/src/config/test.js
@@ -5,7 +5,7 @@ var config = {
 
 if (typeof angular !== "undefined") {
   angular.module("risevision.widget.googleCalendar.config", [])
-    .value("defaultLayout", "http://widgets.risevision.com/widget-google-calendar-test/stage-0/0.1.0/dist/widget.html");
+    .value("defaultLayout", "https://widgets.risevision.com/widget-google-calendar-test/stage-0/0.1.0/dist/widget.html");
 
   angular.module("risevision.common.i18n.config", [])
     .constant("LOCALES_PREFIX", "locales/translation_")


### PR DESCRIPTION
## Description
Change layout URL to load widget from `widgets.risevision.com` instead of `s3.amazonaws.com`

## Motivation and Context
Stop propagation of S3 usage ([Trello card](https://trello.com/c/OOV9y0sv/7833-eliminate-use-of-amazon-s3-for-widgets-stop-propagation-of-s3-usage-3)).

## How Has This Been Tested?
Tested on stage-4. Added Widget using URL and confirmed that correct URL was added to the presentation. Also confirmed that widget is working in preview.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
